### PR TITLE
Add depcheck to find unused dependencies at lint-time

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Add depcheck to linter, used with -u flag
+
 v1.4.2
 
 * Bump coffeescope2

--- a/lib/resin-lint.coffee
+++ b/lib/resin-lint.coffee
@@ -1,3 +1,5 @@
+Promise = require('bluebird')
+depcheck = require('depcheck')
 fs = require('fs')
 path = require('path')
 glob = require('glob')
@@ -8,6 +10,18 @@ reporter = require('coffeelint/lib/reporters/default')
 
 CONFIG_PATH = path.join(__dirname, '../config/coffeelint.json')
 
+# The linter expects the path to actual source files, for example:
+#		src/
+#		test/
+#	but depcheck expects the root of a project directory (where the
+#	package.json is). This function takes a path and propagates upwards
+#	until it contains a package.json
+getPackageJsonDir = (dir) ->
+	name = findFile('package.json', dir)
+	if name is null
+		throw new Error('Could not find package.json!')
+	return path.dirname(name)
+
 read = (path) ->
 	realPath = fs.realpathSync(path)
 	fs.readFileSync(realPath).toString()
@@ -15,7 +29,7 @@ read = (path) ->
 findFile = (name, dir) ->
 	dir = dir or process.cwd()
 	filename = path.join(dir, name)
-	parent = path.resolve(dir, '../')
+	parent = path.dirname(dir)
 	if fs.existsSync(filename)
 		return filename
 	else if dir is parent
@@ -53,35 +67,58 @@ module.exports = (passed_params) ->
 			.describe('f', 'Specify a coffeelint config file to override resin-lint rules')
 			.describe('p', 'Print default resin-lint coffeelint.json')
 			.describe('i', 'Ignore coffeelint.json files in project directory and its parents')
+			.boolean('u', 'Run unused import check')
 
 		if options.argv._.length < 1 and not options.argv.p
 			options.showHelp()
 			process.exit(1)
 
-		if options.argv.p
-			console.log(fs.readFileSync(CONFIG_PATH).toString())
-			process.exit(0)
+		Promise.try ->
+			if options.argv.u
+				return Promise.map options.argv._, (dir) ->
+					dir = getPackageJsonDir(dir)
+					Promise.resolve depcheck path.resolve('./', dir),
+						ignoreMatches: [
+							'@types/*' # ignore typescript type declarations
+							'supervisor' # isn't used directly from source
+							'coffee-script' # Gives false positives
+							'coffeescript' # An alias
+							'colors' # Generally imported via colors/safe, which doesn't trigger depcheck
+							'coffeescope2'
+						]
+					.get('dependencies')
+					.then (deps) ->
+						if deps.length > 0
+							console.log("#{deps.length} unused dependencies:")
+							console.log("\t#{dep}") for dep in deps
+							process.exit(1)
+						console.log('No unused dependencies!')
+						console.log()
+		.then ->
+			if options.argv.p
+				console.log(fs.readFileSync(CONFIG_PATH).toString())
+				process.exit(0)
 
-		config = parseJSON(CONFIG_PATH)
+			config = parseJSON(CONFIG_PATH)
 
-		if options.argv.f
-			configOverridePath = fs.realpathSync(options.argv.f)
+			if options.argv.f
+				configOverridePath = fs.realpathSync(options.argv.f)
 
-		configOverridePath ?= findFile('coffeelint.json') if not options.argv.i
-		if configOverridePath
-			# Override default config
-			configOverride = parseJSON(configOverridePath)
-			config = merge(config, configOverride)
+			configOverridePath ?= findFile('coffeelint.json') if not options.argv.i
+			if configOverridePath
+				# Override default config
+				configOverride = parseJSON(configOverridePath)
+				config = merge(config, configOverride)
 
-		paths = options.argv._
-		scripts = findCoffeeScriptFiles(paths)
+			paths = options.argv._
+			scripts = findCoffeeScriptFiles(paths)
 
-		errorReport = lintFiles(scripts, config)
-		report = new reporter errorReport,
-			colorize: process.stdout.isTTY
-			quiet: false
-		report.publish()
-		process.on 'exit', ->
-			process.exit(errorReport.getExitCode())
+			errorReport = lintFiles(scripts, config)
+			report = new reporter errorReport,
+				colorize: process.stdout.isTTY
+				quiet: false
+			report.publish()
+			process.on 'exit', ->
+				process.exit(errorReport.getExitCode())
 	catch err
 		console.log(err.stack)

--- a/package.json
+++ b/package.json
@@ -22,9 +22,11 @@
   "author": "Kostas Lekkas <kostas@resin.io",
   "license": "Apache 2.0",
   "dependencies": {
+    "bluebird": "^3.5.0",
     "coffee-script": "^1.10.0",
     "coffeelint": "^1.15.0",
     "coffeescope2": "^0.4.5",
+    "depcheck": "^0.6.7",
     "glob": "^7.0.3",
     "merge": "^1.2.0",
     "optimist": "^0.6.1"


### PR DESCRIPTION
Also added a list of modules that should be ignored, such a `@types/[module]` modules, which are never directly imported.

Added some other ones such as `supervisor` which is also never directly imported. If anybody can think of other special-case modules like this please let me know.

Change-type: minor
Signed-off-by: Cameron Diver <cameron@resin.io>