### PR TITLE
Add support for prettier code format checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,27 @@ resin-lint
 ==========
 
 `resin-lint` is a linter based on [coffeelint](https://github.com/clutchski/coffeelint),
-[coffeescope2](https://github.com/za-creature/coffeescope) and [tslint](https://palantir.github.io/tslint/) that detects style errors based on Resin.io coding guidelines.
+[coffeescope2](https://github.com/za-creature/coffeescope), [tslint](https://palantir.github.io/tslint/) and [prettier](https://github.com/prettier/prettier) to detect style errors based on Resin.io coding guidelines.
 
 Overview
 --------
 
-`resin-lint` uses Resin's `coffeelint.json` and `tslint.json`. If a `coffeelint.json` or `tslint.json` is found in the to-be-linted project
+`resin-lint` uses Resin's `coffeelint.json`, `tslint.json` and `.prettierrc`.
+If a `coffeelint.json` or `tslint.json` is found in the to-be-linted project
 directory or its parents then the rules found in it will override the default `resin-lint` ones.
 Another way to to override the default resin-lint rules is by specifying a configuration
 file with the `-f` parameter.
+
+## Typescript
+
 By default, only `.coffee` files will be linted. `.ts` and `.tsx` files can be
 linted by using the `--typescript` parameter.
+
+## Prettier
+
+You can reference the prettier configuration file to your consumer project
+from `./config/.prettierrc`.
+You can disable the prettier format checks by using the `--no-prettier` parameter.
 
 Usage
 -----

--- a/config/.prettierrc
+++ b/config/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"singleQuote": true,
+	"trailingComma": "all",
+	"useTabs": true
+}

--- a/config/tslint.json
+++ b/config/tslint.json
@@ -1,28 +1,22 @@
 {
-  "extends": "tslint:recommended",
+  "extends": [
+    "tslint:recommended",
+    "tslint-config-prettier"
+  ],
   "rules": {
-    "indent": [ true, "tabs" ],
     "jsdoc-format": true,
-    "whitespace": [
-      false,
-      "check-type"
-    ],
     "object-literal-sort-keys": false,
     "only-arrow-functions": [false],
-    "quotemark": [true, "single", "avoid-escape", "jsx-double"],
     "max-classes-per-file": [false],
     "max-line-length": [180],
     "member-access": false,
     "member-ordering": [false],
-    "no-consecutive-blank-lines": false,
     "no-shadowed-variable": false,
     "no-var-requires": true,
-    "arrow-parens": false,
     "no-angle-bracket-type-assertion": false,
     "no-console": [false],
     "no-empty-interface": false,
     "no-string-literal": false,
-    "object-literal-key-quotes": [true, "as-needed"],
     "interface-name": [false],
     "interface-over-type-literal": false,
     "variable-name": [
@@ -31,19 +25,6 @@
       "check-format",
       "allow-leading-underscore",
       "allow-pascal-case"
-    ],
-    "semicolon": [true, "always", "ignore-bound-class-methods"],
-    "trailing-comma": [
-      true,
-      {
-        "multiline": {
-          "objects": "always",
-          "arrays": "always",
-          "functions": "always",
-          "typeLiterals": "ignore"
-        },
-        "esSpecCompliant": true
-      }
     ]
   }
 }

--- a/lib/resin-lint.ts
+++ b/lib/resin-lint.ts
@@ -7,6 +7,7 @@ import * as glob from 'glob';
 const merge: any = require('merge');
 import * as optimist from 'optimist';
 import * as path from 'path';
+import * as prettier from 'prettier';
 import * as tslint from 'tslint';
 
 interface ResinLintConfig {
@@ -14,6 +15,7 @@ interface ResinLintConfig {
 	configFileName: string;
 	extensions: string[];
 	lang: 'coffeescript' | 'typescript';
+	prettierCheck?: boolean,
 }
 
 const configurations: { [key: string]: ResinLintConfig } = {
@@ -30,6 +32,8 @@ const configurations: { [key: string]: ResinLintConfig } = {
 		lang: 'typescript',
 	},
 };
+
+const prettierConfigPath = path.join(__dirname, '../config/.prettierrc');
 
 /**
  * The linter expects the path to actual source files, for example:
@@ -65,7 +69,7 @@ const findFile = function(name: string, dir?: string): string | null {
 	}
 };
 
-const parseJSON = function(file: string): string {
+const parseJSON = function(file: string): {} {
 	try {
 		return JSON.parse(fs.readFileSync(file).toString());
 	} catch (err) {
@@ -105,7 +109,7 @@ const lintCoffeeFiles = function(files: string[], config: {}): number {
 	return  errorReport.getExitCode();
 };
 
-const lintTsFiles = function(files: string[], config: {}): number {
+const lintTsFiles = function(files: string[], config: {}, prettierConfig?: prettier.Options): number {
 	const parsedConfig = tslint.Configuration.parseConfigFile(config);
 	const linter = new tslint.Linter({
 		fix: false,
@@ -114,6 +118,13 @@ const lintTsFiles = function(files: string[], config: {}): number {
 
 	for (const file of files) {
 		const source = read(file);
+		if (prettierConfig) {
+			const isPrettified = prettier.check(source, prettierConfig);
+			if (!isPrettified) {
+				console.log(`Error: File ${file} hasn't been formatted with prettier`);
+				return 1;
+			}
+		}
 		linter.lint(file, source, parsedConfig);
 	}
 
@@ -130,7 +141,13 @@ const runLint = function(resinLintConfig: ResinLintConfig, paths: string[], conf
 	const scripts = findFiles(resinLintConfig.extensions, paths);
 
 	if (resinLintConfig.lang === 'typescript') {
-		linterExitCode = lintTsFiles(scripts, config);
+		let prettierConfig: prettier.Options | undefined;
+		if (resinLintConfig.prettierCheck) {
+			prettierConfig = parseJSON(prettierConfigPath) as prettier.Options;
+			prettierConfig.parser = 'typescript';
+		}
+
+		linterExitCode = lintTsFiles(scripts, config, prettierConfig);
 	}
 
 	if (resinLintConfig.lang === 'coffeescript') {
@@ -148,6 +165,7 @@ export const lint = function(passedParams: any) {
 			.describe('p', 'Print default resin-lint linting rules')
 			.describe('i', 'Ignore linting config files in project directory and its parents')
 			.boolean('typescript', 'Lint typescript files instead of coffeescript')
+			.boolean('no-prettier', 'Disables the prettier code format checks')
 			.boolean('u', 'Run unused import check');
 
 		if ((options.argv._.length < 1) && !options.argv.p) {
@@ -209,6 +227,8 @@ export const lint = function(passedParams: any) {
 			}
 
 			const paths = options.argv._;
+
+			resinLintConfiguration.prettierCheck = !options.argv['no-prettier'];
 
 			return runLint(resinLintConfiguration, paths, config);
 		}).return();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "git@github.com:resin-io/node-resin-lint"
   },
   "scripts": {
-    "test": "npm run lint && ./bin/resin-lint test/ && ./bin/resin-lint test/ --typescript",
+    "test": "npm run lint && ./bin/resin-lint test/ && ./bin/resin-lint test/ --typescript && ./bin/resin-lint test/ --typescript --no-prettier",
     "prepublish": "require-npm4-to-publish",
     "prepublishOnly": "npm run test",
     "lint": "tsc && ./bin/resin-lint lib/"
@@ -28,6 +28,7 @@
     "@types/glob": "^5.0.35",
     "@types/node": "^8.5.2",
     "@types/optimist": "0.0.29",
+    "@types/prettier": "^1.13.2",
     "bluebird": "^3.5.0",
     "coffee-script": "^1.10.0",
     "coffeelint": "^1.15.0",
@@ -36,7 +37,9 @@
     "glob": "^7.0.3",
     "merge": "^1.2.0",
     "optimist": "^0.6.1",
+    "prettier": "^1.14.2",
     "tslint": "^5.8.0",
+    "tslint-config-prettier": "^1.15.0",
     "typescript": "^2.6.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "npm run lint && ./bin/resin-lint test/ && ./bin/resin-lint test/ --typescript && ./bin/resin-lint test/ --typescript --no-prettier",
     "prepublish": "require-npm4-to-publish",
     "prepublishOnly": "npm run test",
-    "lint": "tsc && ./bin/resin-lint lib/"
+    "prettify": "prettier --config ./config/.prettierrc --write \"lib/**/*.ts\"",
+    "lint": "npm run prettify && tsc && ./bin/resin-lint lib/"
   },
   "keywords": [
     "resin",

--- a/test/lintme.ts
+++ b/test/lintme.ts
@@ -5,4 +5,20 @@ const fn = () => ({
 
 const { a, b } = fn();
 
+const x = a
+	? {
+			key: 'A',
+			value: 'B',
+	  }
+	: {};
+
+interface A {
+	aProp:
+		| {
+				key: string;
+				value: string;
+		  }
+		| string;
+}
+
 console.log(a, b);


### PR DESCRIPTION
Adds tslint-config-prettier to the tslint rules so that resin-lint
can be used along with prettier.
Removes the tslint rules that tslint-config-prettier takes care of.
Adds prettier format check along with the TS linting step.

Resolves: #25
Change-type: major
Signed-off-by: Thodoris Greasidis <thodoris@resin.io>
---- Autogenerated Waffleboard Connection: Connects to #25